### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To use ZCREasyBake, your project should have a minimum deployment target of iOS 
 ZCREasyBake can be installed a variety of ways depending on your preference:
 
 * Drag-n-drop files from the `Classes` folder into your project.
-* Add `pod "ZCREasyBake"` to your Podfile for Cocoapods.
+* Add `pod "ZCREasyBake"` to your Podfile for CocoaPods.
 
 However you get the framework into your project, you can import the main header where needed:
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
